### PR TITLE
Update schema.thrift

### DIFF
--- a/src/schema.thrift
+++ b/src/schema.thrift
@@ -21,7 +21,7 @@ enum GenderType {
   FEMALE = 2
 }
 
-union PersonPropertyValue {
+struct PersonPropertyValue {
   1: string full_name;
   2: GenderType gender;
   3: Location location;
@@ -74,7 +74,7 @@ struct Pedigree {
   3: required OrigSystem system;
 }
 
-union DataUnit {
+struct DataUnit {
   1: PersonProperty person_property;
   2: PageProperty page_property;
   3: EquivEdge equiv;


### PR DESCRIPTION
It looks to me like PersonProperttyValue and DataUnit should be structs, not unions.  From the Thrift documentation (https://thrift.apache.org/docs/idl): "Unions are similar to structs, except that they provide a means to transport exactly one field of a possible set of fields, just like union {} in C++."  PersonProperttyValue and DataUnit use multiple fields simultaneously.
